### PR TITLE
NotificationManager: Concentrate LED light capabilities in a single l…

### DIFF
--- a/core/java/android/app/INotificationManager.aidl
+++ b/core/java/android/app/INotificationManager.aidl
@@ -112,4 +112,6 @@ interface INotificationManager
     void applyRestore(in byte[] payload, int user);
 
     ParceledListSlice getAppActiveNotifications(String callingPkg, int userId);
+
+    boolean doLightsSupport(int capability);
 }

--- a/core/java/android/app/NotificationManager.java
+++ b/core/java/android/app/NotificationManager.java
@@ -1025,4 +1025,33 @@ public class NotificationManager
             default: return defValue;
         }
     }
+
+    /** @hide */
+    public static final int LIGHTS_RGB_NOTIFICATION_LED = 1;
+    /** @hide */
+    public static final int LIGHTS_RGB_BATTERY_LED = 2;
+    /** @hide */
+    public static final int LIGHTS_MULTIPLE_NOTIFICATION_LED = 4;
+    /** @hide */
+    public static final int LIGHTS_PULSATING_LED = 8;
+    /** @hide */
+    public static final int LIGHTS_SEGMENTED_BATTERY_LED = 16;
+    /** @hide */
+    public static final int LIGHTS_ADJUSTABLE_NOTIFICATION_LED_BRIGHTNESS = 32;
+
+    /** @hide */
+    public boolean doLightsSupport(final int capability) {
+        final INotificationManager service = getService();
+        if (service == null) {
+            // If the service isn't up yet, assume everything is possible
+            return true;
+        }
+
+        try {
+            return service.doLightsSupport(capability);
+        } catch (RemoteException e) {
+            // If the service isn't up yet, assume everything is possible
+            return true;
+        }
+    }
 }

--- a/core/res/res/values/cm_symbols.xml
+++ b/core/res/res/values/cm_symbols.xml
@@ -22,14 +22,9 @@
 
     <!-- Notification and battery light -->
     <java-symbol type="bool" name="config_intrusiveNotificationLed" />
-    <java-symbol type="bool" name="config_multiColorNotificationLed" />
     <java-symbol type="bool" name="config_intrusiveBatteryLed" />
-    <java-symbol type="bool" name="config_multiColorBatteryLed" />
     <java-symbol type="array" name="notification_light_package_mapping" />
     <java-symbol type="array" name="config_notificationNoAlertsVibePattern" />
-    
-    <!-- LED pulse -->
-    <java-symbol type="bool" name="config_ledCanPulse" />
 
     <java-symbol type="bool" name="config_singleStageCameraKey" />
     <java-symbol type="integer" name="config_longPressOnMenuBehavior" />

--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -983,20 +983,8 @@
     <!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
     <bool name="config_intrusiveNotificationLed">false</bool>
 
-    <!-- Does the notification LED support multiple colors?
-         Used to decide if the user can change the colors -->
-    <bool name="config_multiColorNotificationLed">false</bool>
-
     <!-- Is the battery LED intrusive? Used to decide if there should be a disable option -->
     <bool name="config_intrusiveBatteryLed">false</bool>
-
-    <!-- Does the battery LED support multiple colors?
-         Used to decide if the user can change the colors -->
-    <bool name="config_multiColorBatteryLed">false</bool>
-
-    <!-- Do the battery/notification LEDs support pulsing?
-         Used to decide if we show pulse settings -->
-    <bool name="config_ledCanPulse">true</bool>
 
     <!-- Default value for LED off time when the battery is low on charge in miliseconds -->
     <integer name="config_notificationsBatteryLedOff">2875</integer>

--- a/services/core/java/com/android/server/BatteryService.java
+++ b/services/core/java/com/android/server/BatteryService.java
@@ -28,6 +28,7 @@ import com.android.server.lights.Light;
 import com.android.server.lights.LightsManager;
 
 import android.app.ActivityManagerNative;
+import android.app.NotificationManager;
 import android.content.BroadcastReceiver;
 import android.content.ContentResolver;
 import android.content.Context;
@@ -939,18 +940,18 @@ public final class BatteryService extends SystemService {
 
         public Led(Context context, LightsManager lights) {
             mBatteryLight = lights.getLight(LightsManager.LIGHT_ID_BATTERY);
+            final NotificationManager nm = context.getSystemService(NotificationManager.class);
 
             // Does the Device support changing battery LED colors?
-            mMultiColorLed = context.getResources().getBoolean(
-                    com.android.internal.R.bool.config_multiColorBatteryLed);
+            mMultiColorLed = nm.doLightsSupport(NotificationManager.LIGHTS_RGB_BATTERY_LED);
 
             // Is the notification LED brightness changeable ?
-            mAdjustableNotificationLedBrightness = context.getResources().getBoolean(
-                    org.cyanogenmod.platform.internal.R.bool.config_adjustableNotificationLedBrightness);
+            mAdjustableNotificationLedBrightness = nm.doLightsSupport(
+                    NotificationManager.LIGHTS_ADJUSTABLE_NOTIFICATION_LED_BRIGHTNESS);
 
             // Does the Device have multiple LEDs ?
-            mMultipleNotificationLeds = context.getResources().getBoolean(
-                    org.cyanogenmod.platform.internal.R.bool.config_multipleNotificationLeds);
+            mMultipleNotificationLeds = nm.doLightsSupport(
+                    NotificationManager.LIGHTS_MULTIPLE_NOTIFICATION_LED);
 
             mBatteryLedOn = context.getResources().getInteger(
                     com.android.internal.R.integer.config_notificationsBatteryLedOn);
@@ -959,8 +960,8 @@ public final class BatteryService extends SystemService {
 
             // Does the Device have segmented battery LED support? In this case, we send the level
             // in the alpha channel of the color and let the HAL sort it out.
-            mUseSegmentedBatteryLed = context.getResources().getBoolean(
-                    org.cyanogenmod.platform.internal.R.bool.config_useSegmentedBatteryLed);
+            mUseSegmentedBatteryLed = nm.doLightsSupport(
+                    NotificationManager.LIGHTS_SEGMENTED_BATTERY_LED);
         }
 
         /**

--- a/services/core/java/com/android/server/notification/NotificationManagerService.java
+++ b/services/core/java/com/android/server/notification/NotificationManagerService.java
@@ -1137,8 +1137,8 @@ public class NotificationManagerService extends SystemService {
         mDefaultNotificationLedOff = resources.getInteger(
                 R.integer.config_defaultNotificationLedOff);
 
-        mMultiColorNotificationLed = resources.getBoolean(
-                R.bool.config_multiColorNotificationLed);
+        mMultiColorNotificationLed = doLightsSupport(
+                NotificationManager.LIGHTS_RGB_NOTIFICATION_LED);
 
         mNotificationPulseCustomLedValues = new ArrayMap<String, NotificationLedValues>();
 
@@ -1160,10 +1160,10 @@ public class NotificationManagerService extends SystemService {
                 VIBRATE_PATTERN_MAXLEN,
                 DEFAULT_VIBRATE_PATTERN);
 
-        mAdjustableNotificationLedBrightness = resources.getBoolean(
-                org.cyanogenmod.platform.internal.R.bool.config_adjustableNotificationLedBrightness);
-        mMultipleNotificationLeds = resources.getBoolean(
-                org.cyanogenmod.platform.internal.R.bool.config_multipleNotificationLeds);
+        mAdjustableNotificationLedBrightness = doLightsSupport(
+                NotificationManager.LIGHTS_ADJUSTABLE_NOTIFICATION_LED_BRIGHTNESS);
+        mMultipleNotificationLeds = doLightsSupport(
+                NotificationManager.LIGHTS_MULTIPLE_NOTIFICATION_LED);
 
         mUseAttentionLight = resources.getBoolean(R.bool.config_useAttentionLight);
 
@@ -1417,6 +1417,13 @@ public class NotificationManagerService extends SystemService {
         if (interruptionFilter == mInterruptionFilter) return;
         mInterruptionFilter = interruptionFilter;
         scheduleInterruptionFilterChanged(interruptionFilter);
+    }
+
+    /** @hide */
+    private boolean doLightsSupport(final int capability) {
+        final int capabilities = getContext().getResources().getInteger(
+                org.cyanogenmod.platform.internal.R.integer.config_deviceLightCapabilities);
+        return (capabilities & capability) != 0;
     }
 
     private final IBinder mService = new INotificationManager.Stub() {
@@ -2369,6 +2376,12 @@ public class NotificationManagerService extends SystemService {
             } finally {
                 Binder.restoreCallingIdentity(identity);
             }
+        }
+
+        public boolean doLightsSupport(final int capability) {
+            final int capabilities = getContext().getResources().getInteger(
+                    org.cyanogenmod.platform.internal.R.integer.config_deviceLightCapabilities);
+            return (capabilities & capability) != 0;
         }
     };
 


### PR DESCRIPTION
…ocation

We have a bunch of individual boolean toggles for various LED behaviors
and combinations, which end up getting used as a similarly sprawling bunch
of getResource() calls across various locations. And they keep piling up...

So... create a new overlayable bit field of LED capabilities,
config_deviceLightCapabilities, where we can throw everything
and expand in the future. Remove the obsolete overlays so that
everyone uses the new overlay moving forward.

Change-Id: I7d627914b058861048071fc15776031c4152157f